### PR TITLE
Demonstrate metrics composition style

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
@@ -49,6 +49,7 @@ import com.redhat.lightblue.rest.crud.cmd.ReleaseCommand;
 import com.redhat.lightblue.rest.crud.cmd.SaveCommand;
 import com.redhat.lightblue.rest.crud.cmd.UpdateCommand;
 import com.redhat.lightblue.rest.crud.cmd.RunSavedSearchCommand;
+import com.redhat.lightblue.rest.crud.metrics.DropwizardRequestMetrics;
 import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
 import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 import com.redhat.lightblue.rest.util.QueryTemplateUtils;
@@ -101,7 +102,7 @@ public abstract class AbstractCrudResource {
      * CDI injection.
      */
     private static final RequestMetrics metrics =
-            new RequestMetrics(MetricRegistryFactory.getMetricRegistry());
+            new DropwizardRequestMetrics(MetricRegistryFactory.getMetricRegistry());
 
     @GET
     @LZF

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
@@ -456,7 +456,7 @@ public abstract class AbstractCrudResource {
     @Path("/bulk")
     public Response bulk(String request) {
         Error.reset();
-        CallStatus st = new BulkRequestCommand(request).run();
+        CallStatus st = new BulkRequestCommand(request, metrics).run();
         return Response.status(st.getHttpStatus()).entity(st.toString()).build();
     }
 

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
@@ -49,6 +49,8 @@ import com.redhat.lightblue.rest.crud.cmd.ReleaseCommand;
 import com.redhat.lightblue.rest.crud.cmd.SaveCommand;
 import com.redhat.lightblue.rest.crud.cmd.UpdateCommand;
 import com.redhat.lightblue.rest.crud.cmd.RunSavedSearchCommand;
+import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
+import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 import com.redhat.lightblue.rest.util.QueryTemplateUtils;
 import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.JsonUtils;
@@ -93,6 +95,14 @@ public abstract class AbstractCrudResource {
         java.security.Security.setProperty("networkaddress.cache.ttl", "30");
     }
 
+    /**
+     * Thread-safe, shared static instance for all requests. Registry is also static, so does not
+     * make much difference to inject. If you wanted to inject, you could do so rather easily using
+     * CDI injection.
+     */
+    private static final RequestMetrics metrics =
+            new RequestMetrics(MetricRegistryFactory.getMetricRegistry());
+
     @GET
     @LZF
     @Path("/search/{entity}")
@@ -111,7 +121,7 @@ public abstract class AbstractCrudResource {
         }
         CallStatus st=new FindCommand(freq.getEntityVersion().getEntity(),
                                       freq.getEntityVersion().getVersion(),
-                                      freq.toJson().toString()).run();
+                                      freq.toJson().toString(), metrics).run();
         return Response.status(st.getHttpStatus()).entity(st.toString()).build();
     }
 
@@ -237,7 +247,7 @@ public abstract class AbstractCrudResource {
     @Path("/lock/")
     public Response lock(String request) {
         Error.reset();
-        CallStatus st = getLockCommand(request).run();
+        CallStatus st = getLockCommand(request, metrics).run();
         return Response.status(st.getHttpStatus()).entity(st.toString()).build();
     }
 
@@ -248,7 +258,7 @@ public abstract class AbstractCrudResource {
                             @PathParam("resourceId") String resourceId,
                             @QueryParam("ttl") Long ttl) {
         Error.reset();
-        CallStatus st = new AcquireCommand(domain, callerId, resourceId, ttl).run();
+        CallStatus st = new AcquireCommand(domain, callerId, resourceId, ttl, metrics).run();
         return Response.status(st.getHttpStatus()).entity(st.toString()).build();
     }
 
@@ -411,7 +421,7 @@ public abstract class AbstractCrudResource {
                          String request) {
         Error.reset();
         boolean bstream=stream!=null&&stream;
-        FindCommand f=new FindCommand(entity, version, request,bstream);
+        FindCommand f=new FindCommand(entity, version, request,bstream, metrics);
         CallStatus st=f.run();
         if(!st.hasErrors()&&bstream) {
             // This is how you stream. You put a response stream into
@@ -509,7 +519,7 @@ public abstract class AbstractCrudResource {
                                @QueryParam("maxResults") Long maxResults) throws IOException {
         Error.reset();
         String request=buildSimpleRequest(entity,version,q,p,s,from,to,maxResults).toString();
-        CallStatus st = new FindCommand(null, entity, version, request).run();
+        CallStatus st = new FindCommand(null, entity, version, request, metrics).run();
         return Response.status(st.getHttpStatus()).entity(st.toString()).build();
     }
 

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/AbstractRestCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/AbstractRestCommand.java
@@ -33,6 +33,7 @@ import com.redhat.lightblue.mediator.Mediator;
 import com.redhat.lightblue.rest.CallStatus;
 import com.redhat.lightblue.rest.RestConfiguration;
 import com.redhat.lightblue.rest.crud.RestCrudConstants;
+import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
 import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 import com.redhat.lightblue.util.Error;
 
@@ -42,7 +43,7 @@ import com.redhat.lightblue.util.Error;
  *
  * @author nmalik
  */
-public abstract class AbstractRestCommand extends RequestMetrics{
+public abstract class AbstractRestCommand {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRestCommand.class);
 
     protected static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.withExactBigDecimals(true);

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/AcquireCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/AcquireCommand.java
@@ -21,14 +21,20 @@ package com.redhat.lightblue.rest.crud.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.redhat.lightblue.extensions.synch.Locking;
+import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 
 public class AcquireCommand extends AbstractLockCommand {
 
     private final Long ttl;
 
-    public AcquireCommand(String domain, String caller, String resource, Long ttl) {
-        super(domain, caller, resource);
+    public AcquireCommand(String domain, String caller, String resource, Long ttl, RequestMetrics metrics) {
+        super(domain, caller, resource, metrics);
         this.ttl = ttl;
+    }
+
+    @Override
+    protected String lockCommandName() {
+        return "acquire";
     }
 
     @Override

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/BulkRequestCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/BulkRequestCommand.java
@@ -26,6 +26,7 @@ import com.redhat.lightblue.crud.BulkRequest;
 import com.redhat.lightblue.crud.BulkResponse;
 import com.redhat.lightblue.rest.CallStatus;
 import com.redhat.lightblue.rest.crud.RestCrudConstants;
+import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.JsonUtils;
 
@@ -33,14 +34,20 @@ public class BulkRequestCommand extends AbstractRestCommand {
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkRequestCommand.class);
 
     private final String request;
+    private final RequestMetrics metrics;
 
-    public BulkRequestCommand(String request) {
+    public BulkRequestCommand(String request, RequestMetrics metrics) {
         this.request = request;
+        this.metrics = metrics;
     }
 
     @Override
     public CallStatus run() {
-        startRequestMonitoring("bulkrequest", null, null);
+        // TODO: Bulk should really time each request individually, but this would require
+        // refactoring in lightblue-core. It raises the question: should all of the timing really be
+        // done at the core layer? There is already metrics tracking being done there. We should
+        // probably expand upon that instead of adding to the rest layer.
+        RequestMetrics.Context context = metrics.startBulkRequest();
         LOGGER.debug("bulk request");
         Error.reset();
         Error.push("rest");
@@ -50,7 +57,7 @@ public class BulkRequestCommand extends AbstractRestCommand {
             try {
                 req = getJsonTranslator().parse(BulkRequest.class, JsonUtils.json(request));
             } catch (Exception e) {
-                markRequestException(e);
+                context.markRequestException(e);
                 LOGGER.error("bulk:parse failure: {}", e);
                 return new CallStatus(Error.get(RestCrudConstants.ERR_REST_ERROR, "Error parsing request"));
             }
@@ -60,22 +67,24 @@ public class BulkRequestCommand extends AbstractRestCommand {
                     addCallerId(r);
                 }
             } catch (Exception e) {
-                markRequestException(e);
+                context.markRequestException(e);
                 LOGGER.error("bulk:validate failure: {}", e);
                 return new CallStatus(Error.get(RestCrudConstants.ERR_REST_ERROR, "Request is not valid"));
             }
+            // TODO: Would be nice if we could pass (req, metrics) here. Mediator already has a
+            // `Measure` class. This and RequestMetrics probably should be combined.
             BulkResponse r = getMediator().bulkRequest(req);
             return new CallStatus(r);
         } catch (Error e) {
-            markRequestException(e);
+            context.markRequestException(e);
             LOGGER.error("bulk:generic_error failure: {}", e);
             return new CallStatus(e);
         } catch (Exception e) {
-            markRequestException(e);
+            context.markRequestException(e);
             LOGGER.error("bulk:generic_exception failure: {}", e);
             return new CallStatus(Error.get(RestCrudConstants.ERR_REST_ERROR, e.toString()));
         } finally {
-            endRequestMonitoring();
+            context.endRequestMonitoring();
         }
     }
 }

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/GetLockCountCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/GetLockCountCommand.java
@@ -25,7 +25,7 @@ import com.redhat.lightblue.extensions.synch.Locking;
 public class GetLockCountCommand extends AbstractLockCommand {
 
     public GetLockCountCommand(String domain, String caller, String resource) {
-        super(domain, caller, resource);
+        super(domain, caller, resource, metrics);
     }
 
     @Override

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/LockPingCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/LockPingCommand.java
@@ -25,7 +25,7 @@ import com.redhat.lightblue.extensions.synch.Locking;
 public class LockPingCommand extends AbstractLockCommand {
 
     public LockPingCommand(String domain, String caller, String resource) {
-        super(domain, caller, resource);
+        super(domain, caller, resource, metrics);
     }
 
     @Override

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/ReleaseCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/cmd/ReleaseCommand.java
@@ -25,7 +25,7 @@ import com.redhat.lightblue.extensions.synch.Locking;
 public class ReleaseCommand extends AbstractLockCommand {
 
     public ReleaseCommand(String domain, String caller, String resource) {
-        super(domain, caller, resource);
+        super(domain, caller, resource, metrics);
     }
 
     @Override

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/DropwizardRequestMetrics.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/DropwizardRequestMetrics.java
@@ -1,0 +1,120 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.rest.crud.metrics;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Objects;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+public class DropwizardRequestMetrics implements RequestMetrics {
+
+    private static final String API = "api";
+
+    private final MetricRegistry metricsRegistry;
+
+    public DropwizardRequestMetrics(MetricRegistry metricRegistry) {
+        metricsRegistry = metricRegistry;
+    }
+
+    /**
+     * Create exception namespace for metric reporting based on exception name
+     * 
+     */
+    private static String errorNamespace(String metricNamespace, Throwable exception) {
+        Class<? extends Throwable> actualExceptionClass = unravelReflectionExceptions(exception);
+        return name(metricNamespace, "requests", "exception", actualExceptionClass.getSimpleName());
+    }
+
+    /**
+     * Get to the cause we actually care about in case the bubbled up exception is a
+     * higher level framework exception that encapsulates the stuff we really care
+     * about.
+     * 
+     */
+    private static Class<? extends Throwable> unravelReflectionExceptions(Throwable e) {
+        while (e.getCause() != null
+                && (e instanceof UndeclaredThrowableException || e instanceof InvocationTargetException)) {
+            e = e.getCause();
+        }
+        return e.getClass();
+    }
+
+    @Override
+    public Context startEntityRequest(String operation, String entity, String version) {
+        return new DropwizardContext(name(API, operation, entity, version));
+    }
+
+    @Override
+    public Context startLock(String lockOperation, String domain) {
+        return new DropwizardContext(name(API, "lock", domain, lockOperation));
+    }
+
+    // TODO: I didn't use this but just a demonstration of another request where the parameters are
+    // different
+    @Override
+    public Context startGenerate(String entity, String version, String path) {
+        return new DropwizardContext(name(API, "generate", entity, version, path));
+    }
+
+    @Override
+    public Context startBulkRequest() {
+        // Not very useful :(... can consider alternatives, but should probably refactor more, see
+        // comments in BulkRequestCommand
+        return new DropwizardContext(name(API, "bulk"));
+    }
+
+    public class DropwizardContext implements Context {
+        private final String metricNamespace;
+        private final Timer.Context context;
+        private final Counter activeRequests;
+        private boolean ended = false;
+
+        public DropwizardContext(String metricNamespace) {
+            this.metricNamespace = Objects.requireNonNull(metricNamespace, "metricNamespace");
+            this.context = metricsRegistry.timer(name(metricNamespace, "latency")).time();
+            this.activeRequests = metricsRegistry.counter(name(metricNamespace, "requests", "active"));
+
+            activeRequests.inc();
+        }
+        @Override
+        public void endRequestMonitoring() {
+            // Added this error handling to catch bugs. Might want to synchronize this, or consider
+            // only logging a warning instead. Important point is that we don't decrement counter
+            // again if request already ended.
+            if (ended) {
+                throw new IllegalStateException("Request already ended.");
+            }
+
+            ended = true;
+            activeRequests.dec();
+            context.stop();
+        }
+
+        @Override
+        public void markRequestException(Exception e) {
+            metricsRegistry.meter(errorNamespace(metricNamespace, e)).mark();
+        }
+    }
+}

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/RequestMetrics.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/RequestMetrics.java
@@ -1,66 +1,6 @@
-/*
- Copyright 2013 Red Hat, Inc. and/or its affiliates.
-
- This file is part of lightblue.
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 package com.redhat.lightblue.rest.crud.metrics;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Objects;
-
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-
-public class RequestMetrics {
-
-    private static final String API = "api";
-
-    private final MetricRegistry metricsRegistry;
-
-    public RequestMetrics(MetricRegistry metricRegistry) {
-        metricsRegistry = metricRegistry;
-    }
-
-    /**
-     * Create exception namespace for metric reporting based on exception name
-     * 
-     */
-    private static String errorNamespace(String metricNamespace, Throwable exception) {
-        Class<? extends Throwable> actualExceptionClass = unravelReflectionExceptions(exception);
-        return name(metricNamespace, "requests", "exception", actualExceptionClass.getSimpleName());
-    }
-
-    /**
-     * Get to the cause we actually care about in case the bubbled up exception is a
-     * higher level framework exception that encapsulates the stuff we really care
-     * about.
-     * 
-     */
-    private static Class<? extends Throwable> unravelReflectionExceptions(Throwable e) {
-        while (e.getCause() != null
-                && (e instanceof UndeclaredThrowableException || e instanceof InvocationTargetException)) {
-            e = e.getCause();
-        }
-        return e.getClass();
-    }
-
+public interface RequestMetrics {
     /**
      * Start timers and counters for the request. Use the returned context to complete the request
      * and optionally mark errors if they occur.
@@ -68,54 +8,19 @@ public class RequestMetrics {
      * <p>The returned context itself is not completely thread safe, it is expected to be used by
      * one and only one thread concurrently.
      */
-    public Context startEntityRequest(String operation, String entity, String version) {
-        return new Context(name(API, operation, entity, version));
-    }
+    Context startEntityRequest(String operation, String entity, String version);
 
-    public Context startLock(String lockOperation, String domain) {
-        return new Context(name(API, "lock", domain, lockOperation));
-    }
+    Context startLock(String lockOperation, String domain);
 
     // TODO: I didn't use this but just a demonstration of another request where the parameters are
     // different
-    public Context startGenerate(String entity, String version, String path) {
-        return new Context(name(API, "generate", entity, version, path));
-    }
+    Context startGenerate(String entity, String version, String path);
 
-    public Context startBulkRequest() {
-        // Not very useful :(... can consider alternatives, but should probably refactor more, see
-        // comments in BulkRequestCommand
-        return new Context(name(API, "bulk"));
-    }
+    Context startBulkRequest();
 
-    public class Context {
-        private final String metricNamespace;
-        private final Timer.Context context;
-        private final Counter activeRequests;
-        private boolean ended = false;
+    interface Context {
+        void endRequestMonitoring();
 
-        public Context(String metricNamespace) {
-            this.metricNamespace = Objects.requireNonNull(metricNamespace, "metricNamespace");
-            this.context = metricsRegistry.timer(name(metricNamespace, "latency")).time();
-            this.activeRequests = metricsRegistry.counter(name(metricNamespace, "requests", "active"));
-
-            activeRequests.inc();
-        }
-        public void endRequestMonitoring() {
-            // Added this error handling to catch bugs. Might want to synchronize this, or consider
-            // only logging a warning instead. Important point is that we don't decrement counter
-            // again if request already ended.
-            if (ended) {
-                throw new IllegalStateException("Request already ended.");
-            }
-
-            ended = true;
-            activeRequests.dec();
-            context.stop();
-        }
-
-        public void markRequestException(Exception e) {
-            metricsRegistry.meter(errorNamespace(metricNamespace, e)).mark();
-        }
+        void markRequestException(Exception e);
     }
 }

--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/RequestMetrics.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/metrics/RequestMetrics.java
@@ -76,6 +76,18 @@ public class RequestMetrics {
         return new Context(name(API, "lock", domain, lockOperation));
     }
 
+    // TODO: I didn't use this but just a demonstration of another request where the parameters are
+    // different
+    public Context startGenerate(String entity, String version, String path) {
+        return new Context(name(API, "generate", entity, version, path));
+    }
+
+    public Context startBulkRequest() {
+        // Not very useful :(... can consider alternatives, but should probably refactor more, see
+        // comments in BulkRequestCommand
+        return new Context(name(API, "bulk"));
+    }
+
     public class Context {
         private final String metricNamespace;
         private final Timer.Context context;

--- a/crud/src/test/java/com/redhat/lightblue/rest/crud/cmd/FindCommandTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/crud/cmd/FindCommandTest.java
@@ -18,8 +18,7 @@
  */
 package com.redhat.lightblue.rest.crud.cmd;
 
-import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
-import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
+import com.redhat.lightblue.rest.metrics.NoopRequestMetrics;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,7 +30,8 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithReturn() {
-        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"data\"}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
+        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"data\"}",
+                new NoopRequestMetrics());
 
         String output = command.run().toString();
 
@@ -42,7 +42,8 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithParseProblem() {
-        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"invalid}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
+        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"invalid}",
+                new NoopRequestMetrics());
 
         String output = command.run().toString();
 
@@ -53,7 +54,8 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithInvalid() {
-        FindCommand command = new FindCommand(mediator, null, "version", "{\"request\":\"invalid\"}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
+        FindCommand command = new FindCommand(mediator, null, "version", "{\"request\":\"invalid\"}",
+                new NoopRequestMetrics());
 
         String output = command.run().toString();
 

--- a/crud/src/test/java/com/redhat/lightblue/rest/crud/cmd/FindCommandTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/crud/cmd/FindCommandTest.java
@@ -18,6 +18,9 @@
  */
 package com.redhat.lightblue.rest.crud.cmd;
 
+import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
+import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +31,7 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithReturn() {
-        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"data\"}");
+        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"data\"}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
 
         String output = command.run().toString();
 
@@ -39,7 +42,7 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithParseProblem() {
-        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"invalid}");
+        FindCommand command = new FindCommand(mediator, "name", "version", "{\"request\":\"invalid}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
 
         String output = command.run().toString();
 
@@ -50,7 +53,7 @@ public class FindCommandTest extends AbstractRestCommandTest {
 
     @Test
     public void runFindWithInvalid() {
-        FindCommand command = new FindCommand(mediator, null, "version", "{\"request\":\"invalid\"}");
+        FindCommand command = new FindCommand(mediator, null, "version", "{\"request\":\"invalid\"}", new RequestMetrics(MetricRegistryFactory.getMetricRegistry()));
 
         String output = command.run().toString();
 

--- a/crud/src/test/java/com/redhat/lightblue/rest/metrics/DropwizardRequestMetricsTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/metrics/DropwizardRequestMetricsTest.java
@@ -25,13 +25,14 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
+
+import com.redhat.lightblue.rest.crud.metrics.DropwizardRequestMetrics;
 import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 
-public class RequestMetricsTest {
+public class DropwizardRequestMetricsTest {
     // Use fresh registry for each test
     private MetricRegistry metricsRegistry = new MetricRegistry();
-    private RequestMetrics requestMetrics = new RequestMetrics(metricsRegistry);
+    private RequestMetrics requestMetrics = new DropwizardRequestMetrics(metricsRegistry);
 
     @Test
     public void testStartRequestMonitoring() {
@@ -49,7 +50,7 @@ public class RequestMetricsTest {
 
     @Test
     public void testEndRequestMonitoring() {
-        RequestMetrics.Context context = requestMetrics.startEntityRequest("explain", "name", "version");
+        DropwizardRequestMetrics.Context context = requestMetrics.startEntityRequest("explain", "name", "version");
         context.endRequestMonitoring();
 
         Counter activeRequestCounter = metricsRegistry.counter("api.explain.name.version.requests.active");
@@ -62,7 +63,7 @@ public class RequestMetricsTest {
 
     @Test
     public void testMarkRequestException() {
-        RequestMetrics.Context context = requestMetrics.startEntityRequest("insert", "name", "version");
+        DropwizardRequestMetrics.Context context = requestMetrics.startEntityRequest("insert", "name", "version");
         context.markRequestException(new NullPointerException());
         
         Meter exceptionMeter = metricsRegistry.meter("api.insert.name.version.requests.exception.NullPointerException");

--- a/crud/src/test/java/com/redhat/lightblue/rest/metrics/NoopRequestMetrics.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/metrics/NoopRequestMetrics.java
@@ -1,0 +1,40 @@
+package com.redhat.lightblue.rest.metrics;
+
+import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
+
+public class NoopRequestMetrics implements RequestMetrics {
+
+    private static final NoopContext NOOP_CONTEXT = new NoopContext();
+
+    @Override
+    public Context startEntityRequest(String operation, String entity, String version) {
+        return NOOP_CONTEXT;
+    }
+
+    @Override
+    public Context startLock(String lockOperation, String domain) {
+        return NOOP_CONTEXT;
+    }
+
+    @Override
+    public Context startGenerate(String entity, String version, String path) {
+        return NOOP_CONTEXT;
+    }
+
+    @Override
+    public Context startBulkRequest() {
+        return NOOP_CONTEXT;
+    }
+
+    private static class NoopContext implements Context {
+        @Override
+        public void endRequestMonitoring() {
+
+        }
+
+        @Override
+        public void markRequestException(Exception e) {
+
+        }
+    }
+}

--- a/crud/src/test/java/com/redhat/lightblue/rest/metrics/RequestMetricsTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/metrics/RequestMetricsTest.java
@@ -29,13 +29,13 @@ import com.redhat.lightblue.rest.crud.metrics.MetricRegistryFactory;
 import com.redhat.lightblue.rest.crud.metrics.RequestMetrics;
 
 public class RequestMetricsTest {
-    private RequestMetrics requestMetrics = new RequestMetrics();
+    private RequestMetrics requestMetrics = new RequestMetrics(MetricRegistryFactory.getMetricRegistry());
     
     private static MetricRegistry metricsRegistry = MetricRegistryFactory.getMetricRegistry();;
 
     @Test
     public void testStartRequestMonitoring() {
-        requestMetrics.startRequestMonitoring("bulk", null, null);
+        requestMetrics.startEntityRequest("bulk", null, null);
         Assert.assertNotNull(metricsRegistry.getCounters());
         Assert.assertNotNull(metricsRegistry.getTimers());
 
@@ -49,7 +49,7 @@ public class RequestMetricsTest {
 
     @Test
     public void testEndRequestMonitoring() {
-        requestMetrics.startRequestMonitoring("explain", "name", "version");
+        requestMetrics.startEntityRequest("explain", "name", "version");
         requestMetrics.endRequestMonitoring();
 
         Counter activeRequestCounter = metricsRegistry.counter("api.explain.name.version.requests.active");
@@ -62,7 +62,7 @@ public class RequestMetricsTest {
 
     @Test
     public void testMarkRequestException() {
-        requestMetrics.startRequestMonitoring("insert", "name", "version");        
+        requestMetrics.startEntityRequest("insert", "name", "version");
         requestMetrics.markRequestException(new NullPointerException());
         
         Meter exceptionMeter = metricsRegistry.meter("api.insert.name.version.requests.exception.NullPointerException");


### PR DESCRIPTION
Hey Sunny, so this is kind of what I was talking about. It doesn't compile, I only updated a few of the commands just to demonstrate some of those points.

In particular notice the different request starting methods based on requests that have very different parameters, and that all of the state for a particular tracked request is kept in the separate Context object, mirroring how dropwizard itself works a bit.

I also showed how because the RequestMetrics are injected now, we can elegantly have differently implementations, like for tests. We are no longer tied to global state.

You don't have to merge if you'd rather attempt this refactoring yourself, but in the interest of time my suggestion would be to merge this and finish it out / improve upon it as you see fit.

If you have any questions, please let me know.

On a different note, I realized while doing this that we should consider moving some of this code to lightblue-core. There are two reasons for this. One is that if we did that, we would be able to better monitor bulk requests, which are currently too much of a black box to be useful, it's hardly even worth gathering metrics on them as is. The second is that core already has some code that is tracking metrics with the Measure class, but it is very basic. What would make sense is to take the more advanced code that we have, and move that to core. This would allow core to participate in metrics gathering, removing redundant code, and then we can publish that to JMX with dropwizard like we're doing here.

That said, I think it's fine if we keep it in lightblue-rest for now. We can refactor for bulk improvements later.

Thanks!

